### PR TITLE
python-mutagen: change SRC_URI to a valid one location

### DIFF
--- a/meta-openpli/recipes-devtools/python/python-mutagen_1.18.bb
+++ b/meta-openpli/recipes-devtools/python/python-mutagen_1.18.bb
@@ -2,20 +2,22 @@ SUMMARY = "Module for manipulating ID3 (v1 + v2) tags in Python"
 SECTION = "devel/python"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=94d55d512a9ba36caa9b7df079bae19f"
-SRCNAME = "mutagen"
+SRCNAME = "mutagen-${PV}"
 PR = "r1"
 
 DEPENDS = "python"
 RDEPENDS_${PN} = "python-shell"
 
-SRC_URI = "http://mutagen.googlecode.com/files/mutagen-${PV}.tar.gz \
+MD5SUM = "0c2cd954e4bacd79fadd45afc4acce4c"
+
+SRC_URI = "http://pkgs.fedoraproject.org/repo/pkgs/${PN}/${SRCNAME}.tar.gz/${MD5SUM}/${SRCNAME}.tar.gz \
 	file://patch.diff \
 "
 
-SRC_URI[md5sum] = "0c2cd954e4bacd79fadd45afc4acce4c"
+SRC_URI[md5sum] = "${MD5SUM}"
 SRC_URI[sha256sum] = "30b6147baf59ab3609939acf49a1a1c73b15d8b1c637a01bfee89da7feea0d6c"
 
-S = "${WORKDIR}/mutagen-${PV}"
+S = "${WORKDIR}/${SRCNAME}"
 
 inherit distutils
 


### PR DESCRIPTION
python-mutagen: change SRC_URI to a valid one location
Since googlecode was gone.
https://github.com/OpenPLi/openpli-oe-core/commit/a21f6733146a8cdfa2819143cf9039416200ce02
